### PR TITLE
fix: add cookie fallback for Aruma session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,7 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+# Local Playwright/debug artifacts
+.playwright-mcp/
+network2.txt

--- a/gs-sdk/src/api/index.js
+++ b/gs-sdk/src/api/index.js
@@ -22,6 +22,7 @@ import {
   setGAIdAccepted,
   getGAIdRejected,
   setGAIdRejected,
+  configureStorage,
 } from "../utils/storage";
 import {
   jsonToQueryString,
@@ -43,10 +44,13 @@ window.gsStore = {
   interactionCount: 0,
 };
 
+const COOKIE_FALLBACK_CLIENT_IDS = ["aPlEvUhcwYr76idR"];
+
 export const init = async (clientId, options) => {
   if (options.playgroundToken) {
     clearSession();
     clientId = configure(clientId);
+    configureStorage({ cookieFallback: COOKIE_FALLBACK_CLIENT_IDS.includes(clientId) });
     setClientId(clientId);
     setSession({
       token: options.playgroundToken,
@@ -58,6 +62,7 @@ export const init = async (clientId, options) => {
   window.gsConfig.includeDraft = options.includeDraft;
 
   clientId = configure(clientId);
+  configureStorage({ cookieFallback: COOKIE_FALLBACK_CLIENT_IDS.includes(clientId) });
   const clientOrigin = window.location.origin;
 
   const sameClientId = checkSameClientId(clientId);

--- a/gs-sdk/src/utils/storage.js
+++ b/gs-sdk/src/utils/storage.js
@@ -1,15 +1,107 @@
 const key = "gs-v-1";
 const GS_VUUID = "gs_vuuid";
 const GS_GAID = "gs_gaid";
+const COOKIE_MAX_BYTES = 3500;
+const COOKIE_SESSION_TTL_SECONDS = 24 * 60 * 60;
+const COOKIE_ID_TTL_SECONDS = 365 * 24 * 60 * 60;
 
 
 // Keys for GA4 session sync in traffic split
 const GS_GAID_ACCEPTED = "gs_gaid_accepted";
 const GS_GAID_REJECTED = "gs_gaid_rejected";
+const COOKIE_FALLBACK_KEYS = [key, `${key}-clientId`, GS_VUUID];
+
+let cookieFallbackEnabled = false;
+
+export const configureStorage = ({ cookieFallback = false } = {}) => {
+  cookieFallbackEnabled = cookieFallback === true;
+};
+
+const canUseCookieFallback = (storageKey) => {
+  return cookieFallbackEnabled && COOKIE_FALLBACK_KEYS.includes(storageKey) && typeof document !== "undefined";
+};
+
+const byteLength = (value) => {
+  if (typeof TextEncoder !== "undefined") {
+    return new TextEncoder().encode(value).length;
+  }
+  return encodeURIComponent(value).replace(/%[0-9A-F]{2}/g, "x").length;
+};
+
+const getCookieValue = (storageKey) => {
+  if (!canUseCookieFallback(storageKey) || !document.cookie) {
+    return null;
+  }
+
+  const name = `${encodeURIComponent(storageKey)}=`;
+  const cookies = document.cookie.split("; ");
+  const cookie = cookies.find((item) => item.startsWith(name));
+  if (!cookie) {
+    return null;
+  }
+
+  try {
+    return decodeURIComponent(cookie.slice(name.length));
+  } catch (e) {
+    return null;
+  }
+};
+
+const deleteCookieValue = (storageKey) => {
+  if (!canUseCookieFallback(storageKey)) {
+    return;
+  }
+
+  const secure = window.location.protocol === "https:" ? "; Secure" : "";
+  document.cookie = `${encodeURIComponent(storageKey)}=; Path=/; Max-Age=0; SameSite=Lax${secure}`;
+};
+
+const setCookieValue = (storageKey, value) => {
+  if (!canUseCookieFallback(storageKey)) {
+    return;
+  }
+
+  const maxAge = storageKey === key ? COOKIE_SESSION_TTL_SECONDS : COOKIE_ID_TTL_SECONDS;
+  const secure = window.location.protocol === "https:" ? "; Secure" : "";
+  const cookie = `${encodeURIComponent(storageKey)}=${encodeURIComponent(value)}; Path=/; Max-Age=${maxAge}; SameSite=Lax${secure}`;
+
+  if (byteLength(cookie) > COOKIE_MAX_BYTES) {
+    deleteCookieValue(storageKey);
+    window.gsLog?.("Cookie fallback skipped because value is too large", storageKey);
+    return;
+  }
+
+  document.cookie = cookie;
+};
+
+const getStorageItem = (storageKey) => {
+  const item = localStorage.getItem(storageKey);
+  if (item !== null) {
+    return item;
+  }
+
+  const cookieValue = getCookieValue(storageKey);
+  if (cookieValue !== null) {
+    localStorage.setItem(storageKey, cookieValue);
+    return cookieValue;
+  }
+
+  return null;
+};
+
+const setStorageItem = (storageKey, value) => {
+  localStorage.setItem(storageKey, value);
+  setCookieValue(storageKey, value);
+};
+
+const removeStorageItem = (storageKey) => {
+  localStorage.removeItem(storageKey);
+  deleteCookieValue(storageKey);
+};
 
 
 export const getToken = () => {
-  const item = localStorage.getItem(key);
+  const item = getStorageItem(key);
   if (!item) {
     return {};
   }
@@ -17,7 +109,7 @@ export const getToken = () => {
 };
 
 export const checkSameClientId = (clientId) => {
-  const item = localStorage.getItem(key + "-clientId");
+  const item = getStorageItem(key + "-clientId");
   if (!item) {
     return false;
   }
@@ -25,11 +117,11 @@ export const checkSameClientId = (clientId) => {
 };
 
 export const setClientId = (clientId) => {
-  localStorage.setItem(key + "-clientId", clientId);
+  setStorageItem(key + "-clientId", clientId);
 };
 
 export const isTokenValid = () => {
-  const item = localStorage.getItem(key);
+  const item = getStorageItem(key);
   if (!item) {
     return false;
   }
@@ -46,7 +138,7 @@ export const isTokenValid = () => {
 };
 
 export const getSession = () => {
-  const item = localStorage.getItem(key);
+  const item = getStorageItem(key);
   if (item) {
     const session = JSON.parse(item);
     const vuuid = getVUUID();
@@ -58,7 +150,7 @@ export const getSession = () => {
 };
 
 export const addDataToSession = (fieldKey, value) => {
-  const item = localStorage.getItem(key);
+  const item = getStorageItem(key);
   if (item) {
     const session = JSON.parse(item);
     session[fieldKey] = value;
@@ -72,20 +164,20 @@ export const setSession = (data = {}, preserveTs = false) => {
   if (!preserveTs) {
     data.ts = new Date();
   }
-  localStorage.setItem(key, JSON.stringify(data));
+  setStorageItem(key, JSON.stringify(data));
   return data;
 };
 
 export const clearSession = () => {
-  localStorage.removeItem(key);
+  removeStorageItem(key);
   localStorage.removeItem("gs_content_seen");
 };
 
 export const setVUUID = (value) => {
-  localStorage.setItem(GS_VUUID, value);
+  setStorageItem(GS_VUUID, value);
 };
 export const getVUUID = () => {
-  const item = localStorage.getItem(GS_VUUID);
+  const item = getStorageItem(GS_VUUID);
   return item;
 };
 


### PR DESCRIPTION
## Summary\n- add a cookie-backed fallback for session storage keys\n- enable it only for normalized clientId `aPlEvUhcwYr76idR`\n- ignore local Playwright/debug artifacts\n\n## Verification\n- `npm run build`